### PR TITLE
Script to get Dark Sky Weather Data as JSON

### DIFF
--- a/Weather Data.ipynb
+++ b/Weather Data.ipynb
@@ -11,7 +11,8 @@
     "import requests\n",
     "import datetime\n",
     "\n",
-    "%pylab inline"
+    "# Dark Sky API key\n",
+    "api_key_input = ''"
    ]
   },
   {
@@ -57,14 +58,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get DarkSky data from API\n",
+    "# Setup\n",
     "\n",
-    "api_key = '979f0837a4bf901fbed916c72790e3f5'\n",
-    "lat_long = '40.758896,-73.985130'\n",
-    "date = '2018-02-02T00:00:00' # Must be [YYYY]-[MM]-[DD]T[HH]:[MM]:[SS] or UNIX timestamp\n",
-    "\n",
-    "response = requests.get('https://api.darksky.net/forecast/979f0837a4bf901fbed916c72790e3f5/40.758896,-73.985130,' + date + '?exclude=daily,currently,alerts,flags')\n",
-    "response = response.json()"
+    "api_key = api_key_input\n",
+    "lat_long = '40.758896,-73.985130' # Times Square"
    ]
   },
   {
@@ -97,7 +94,7 @@
     }
    ],
    "source": [
-    "# Short version of dates for testing\n",
+    "# Short version of dates for testing/printing\n",
     "\n",
     "dateShort = dateList[0:5]\n",
     "\n",
@@ -152,15 +149,6 @@
     "# with open('DarkSky_Data.json', 'w') as outfile:\n",
     "#     json.dump(data_list, outfile)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -179,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Get hourly weather for Times Square, New York City from Dark Sky for 2006-2016. Format as JSON and save locally.